### PR TITLE
feat/#1 node-cron migration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@prisma/client": "^6.4.1",
+        "dotenv": "^16.4.7",
         "node-cron": "^3.0.3"
       },
       "devDependencies": {
@@ -622,6 +623,17 @@
       "dev": true,
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.4.7",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
+      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/esbuild": {

--- a/package.json
+++ b/package.json
@@ -2,11 +2,12 @@
   "name": "todo-hunter-cron",
   "version": "1.0.0",
   "description": "todo hunter node cron project",
-  "main": "index.js",
+  "main": "dist/index.js",
+  "type": "module",
   "scripts": {
     "build": "tsc",
     "start": "node dist/index.js",
-    "dev": "ts-node src/index.ts"
+    "dev": "node --loader ts-node/esm src/index.ts"
   },
   "keywords": [],
   "author": "",
@@ -20,6 +21,7 @@
   },
   "dependencies": {
     "@prisma/client": "^6.4.1",
+    "dotenv": "^16.4.7",
     "node-cron": "^3.0.3"
   }
 }

--- a/src/crons/ending-close-cron.ts
+++ b/src/crons/ending-close-cron.ts
@@ -1,0 +1,25 @@
+import { PrismaClient } from "@prisma/client";
+import { CronJob } from "../types/cron-type.js";
+
+// 엔딩 close 크론잡 (all 유저)
+const EndingCloseCron: CronJob = {
+  name: "캐릭터 엔딩 close 업데이트",
+  schedule: "0 0 * * 1", // 매주 월요일 자정
+  task: async (prisma: PrismaClient) => {
+    try {
+      const result = await prisma.character.updateMany({
+        where: {},
+        data: {
+          endingState: 1,
+        },
+      });
+      console.log(
+        `[${EndingCloseCron.name}] ${result.count}개의 character endingState가 업데이트되었습니다.`
+      );
+    } catch (error) {
+      console.log(`[${EndingCloseCron.name}] 실패:`, error);
+    }
+  },
+};
+
+export default EndingCloseCron;

--- a/src/crons/ending-open-cron.ts
+++ b/src/crons/ending-open-cron.ts
@@ -1,0 +1,27 @@
+import { PrismaClient } from "@prisma/client";
+import { CronJob } from "../types/cron-type.js";
+
+// 엔딩 open 크론잡 (pending 유저 X)
+const EndingOpenCron: CronJob = {
+  name: "캐릭터 엔딩 open 업데이트",
+  schedule: "0 0 * * 0", // 매주 일요일 자정
+  task: async (prisma: PrismaClient) => {
+    try {
+      const result = await prisma.character.updateMany({
+        where: {
+          endingState: 1,
+        },
+        data: {
+          endingState: 2,
+        },
+      });
+      console.log(
+        `[${EndingOpenCron.name}] ${result.count}개의 character endingState가 업데이트되었습니다.`
+      );
+    } catch (error) {
+      console.log(`[${EndingOpenCron.name}] 실패:`, error);
+    }
+  },
+};
+
+export default EndingOpenCron;

--- a/src/crons/index.ts
+++ b/src/crons/index.ts
@@ -1,0 +1,42 @@
+import { PrismaClient } from "@prisma/client";
+import cron from "node-cron";
+import { CronJob } from "../types/cron-type.js";
+import EndingCloseCron from "./ending-close-cron.js";
+import EndingOpenCron from "./ending-open-cron.js";
+import StatusResetCron from "./status-reset-cron.js";
+import TestLogCron from "./test-log-cron.js";
+
+// 모든 크론잡 목록
+const cronJobs: CronJob[] = [
+  ...(process.env.NODE_ENV === "development" ? [TestLogCron] : []),
+  EndingOpenCron, // 일요일 자정
+  EndingCloseCron, // 월요일 자정 (먼저 실행)
+  StatusResetCron, // 월요일 자정 (나중에 실행)
+];
+
+// 크론잡 초기화 함수
+const InitCron = (prisma: PrismaClient) => {
+  cronJobs.forEach((job) => {
+    if (!cron.validate(job.schedule)) {
+      console.error(`[${job.name}] 잘못된 크론 스케줄: ${job.schedule}`);
+      return;
+    }
+
+    cron.schedule(job.schedule, async () => {
+      console.log(`[${job.name}] 작업 시작`);
+      const startTime = new Date();
+
+      try {
+        await job.task(prisma);
+        const duration = new Date().getTime() - startTime.getTime();
+        console.log(`[${job.name}] 작업 완료 (소요시간: ${duration}ms)`);
+      } catch (error) {
+        console.error(`[${job.name}] 작업 실패:`, error);
+      }
+    });
+
+    console.log(`[${job.name}] 등록 완료 (스케줄: ${job.schedule})`);
+  });
+};
+
+export default InitCron;

--- a/src/crons/status-reset-cron.ts
+++ b/src/crons/status-reset-cron.ts
@@ -1,0 +1,29 @@
+import { PrismaClient } from "@prisma/client";
+import { CronJob } from "../types/cron-type.js";
+
+// 스테이터스 초기화 크론잡 (all 유저)
+const StatusResetCron: CronJob = {
+  name: "캐릭터 status 초기화",
+  schedule: "0 0 * * 1", // 매주 월요일 자정
+  task: async (prisma: PrismaClient) => {
+    try {
+      const result = await prisma.status.updateMany({
+        where: {},
+        data: {
+          str: 0,
+          int: 0,
+          emo: 0,
+          fin: 0,
+          liv: 0,
+        },
+      });
+      console.log(
+        `[${StatusResetCron.name}] ${result.count}개의 character status가 초기화되었습니다.`
+      );
+    } catch (error) {
+      console.log(`[${StatusResetCron.name}] 실패:`, error);
+    }
+  },
+};
+
+export default StatusResetCron;

--- a/src/crons/test-log-cron.ts
+++ b/src/crons/test-log-cron.ts
@@ -1,0 +1,20 @@
+import { PrismaClient } from "@prisma/client";
+import { CronJob } from "../types/cron-type.js";
+
+// 테스트용 로그 출력 크론잡
+const TestLogCron: CronJob = {
+  name: "테스트 로그 출력",
+  schedule: "*/10 * * * * *", // 10초마다 실행
+  task: async (prisma: PrismaClient) => {
+    try {
+      const now = new Date();
+      console.log(
+        `[${TestLogCron.name}] 크론잡 정상 동작 중 - ${now.toLocaleString()}`
+      );
+    } catch (error) {
+      console.error(`[${TestLogCron.name}] 실패:`, error);
+    }
+  },
+};
+
+export default TestLogCron;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,58 @@
+import "dotenv/config";
+import { prisma } from "./lib/prisma.js";
+import InitCron from "./crons/index.js";
+
+// 애플리케이션 종료 시 정리 작업을 수행하는 함수
+async function cleanup() {
+  console.log("[크론 워커] 정리 작업 시작...");
+  try {
+    await prisma.$disconnect();
+    console.log("[크론 워커] DB 연결 해제 완료");
+  } catch (error) {
+    console.error("[크론 워커] 정리 작업 중 오류:", error);
+    process.exit(1); // 오류 발생 시 프로세스 종료 (1: 비정상 종료)
+  }
+}
+
+// 애플리케이션의 메인 함수
+async function main() {
+  try {
+    console.log("[크론 워커] 시작됨");
+    console.log("[크론 워커] 환경:", process.env.NODE_ENV);
+
+    await InitCron(prisma);
+    console.log("[크론 워커] 크론 작업 초기화 완료");
+  } catch (error) {
+    console.error("[크론 워커] 애플리케이션 시작 실패:", error);
+    await cleanup();
+    process.exit(1);
+  }
+}
+
+// SIGTERM (종료 요청) 시그널 처리
+process.on("SIGTERM", async () => {
+  console.log("[크론 워커] SIGTERM 신호 수신");
+  await cleanup();
+  process.exit(0); // 정상 종료 (0: 정상 종료)
+});
+
+// SIGINT (인터럽트) 시그널 처리
+process.on("SIGINT", async () => {
+  console.log("[크론 워커] SIGINT 신호 수신");
+  await cleanup();
+  process.exit(0);
+});
+
+// 처리되지 않은 예외 처리
+process.on("uncaughtException", async (error) => {
+  console.error("[크론 워커] 처리되지 않은 예외:", error);
+  await cleanup();
+  process.exit(1);
+});
+
+// 처리되지 않은 Promise 거부 처리
+process.on("unhandledRejection", async (reason) => {
+  console.error("[크론 워커] 처리되지 않은 Promise 거부:", reason);
+});
+
+main();

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,0 +1,6 @@
+import { PrismaClient } from "@prisma/client";
+
+const globalForPrisma = global as unknown as { prisma: PrismaClient };
+export const prisma = globalForPrisma.prisma || new PrismaClient();
+
+if (process.env.NODE_ENV !== "production") globalForPrisma.prisma = prisma;

--- a/src/types/cron-type.ts
+++ b/src/types/cron-type.ts
@@ -1,0 +1,7 @@
+import { PrismaClient } from "@prisma/client";
+
+export type CronJob = {
+  name: string;
+  schedule: string;
+  task: (prisma: PrismaClient) => Promise<void>;
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,9 @@
 {
   "compilerOptions": {
-    "target": "ES2022",
-    "module": "CommonJS",
-    "lib": ["ES2022"],
+    "target": "ESNext",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ESNext"],
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## 📌 작업 상세

> node-cron migration issue #1 

- 기존 todo-hunter 브런치에서 작업한 node-cron 을 해당 repository 로 분리하였습니다.
- 프로젝트 분리로 인한 엔트리포인트 구성에 따라 node 환경에 맞게 코드를 변경, 추가하였습니다.
- 하나의 db 를 공유함으로 메인 프로젝트와 동일한 prisma schema 를 이전해왔습니다.
- prisma client 인스턴스 다중 생성을 방지하기 위한 파일을 추가하였습니다.
- ts 프로젝트에서 애플리케이션 코드가 env에 접근하기 위한 dotenv 라이브러리를 추가하였습니다.